### PR TITLE
Update documentation to use reddit('/path/').get()

### DIFF
--- a/oauth-script.md
+++ b/oauth-script.md
@@ -32,7 +32,7 @@ var reddit = new Snoocore({
 // To authenticate with OAuth, simply call `auth()`
 return reddit.auth().then(function() {
     // Make an OAuth call to show that it is working
-    return reddit.api.v1.me.get();
+    return reddit('/api/v1/me').get();
 })
 .then(function(data) {
     console.log(data); // Log the response


### PR DESCRIPTION
As on tin. Fixes a documentation issue and a stumbling block for new users - this was brought up in #reddit_dev.