### PR TITLE
Fix examples link in listings docs

### DIFF
--- a/listings.md
+++ b/listings.md
@@ -43,7 +43,7 @@ reddit('/r/hot').listing({ limit: 10 }).then(function(slice) {
 });
 ```
 
-For full working examples checkout the [examples on GitHub](https://github.com/trevorsenior/snoocore/tree/master/examples)
+For full working examples checkout the [examples on GitHub](https://github.com/trevorsenior/snoocore-examples/tree/master)
 
 - - -
 


### PR DESCRIPTION
**Fix examples link in listings docs** to point to the snoocore-examples repo *(found while browsing the awesome docs!)*