### PR TITLE
Fix XMLHttpRequest failed on node-webkit

### DIFF
--- a/request/requestBrowser.js
+++ b/request/requestBrowser.js
@@ -19,7 +19,7 @@ exports.https = function(options, formData) {
 
     try {
       // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
-      var x = new XMLHttpRequest();
+      var x = new window.XMLHttpRequest();
 
       var url = 'https://' + options.hostname + options.path;
 


### PR DESCRIPTION
Hello.
On node-webkit, `XMLHttpRequest` failed becase this method is not a global object.
This patch fixes this problem by bringing from the global object `window`.

jQuery library also doing the same.
https://github.com/jquery/jquery/blob/master/src/ajax/xhr.js#L9

Thanks, regards.