### PR TITLE
Add support for uploading images in the browser

### DIFF
--- a/src/https/file.js
+++ b/src/https/file.js
@@ -3,8 +3,11 @@ Represents a file that we wish to upload to reddit.
 
 All files have a name, mimeType, and data. 
 
-data can be a `utf8` string, or a buffer containing the 
-content of the file.
+In the browser data can be a `File` object directly from
+a file input, or a `Blob` object.
+
+In node, data can be a `utf8` string, or a buffer
+containing the content of the file.
 */
 
 export default function(name, mimeType, data) {
@@ -12,7 +15,13 @@ export default function(name, mimeType, data) {
 
   self.name = name;
   self.mimeType = mimeType;
-  self.data = (typeof data === 'string') ? new Buffer(data) : data;
+
+  if (typeof File !== 'undefined' && data instanceof File ||
+      typeof Blob !== 'undefined' && data instanceof Blob) {
+    self.data = data;
+  } else {
+    self.data = (typeof data === 'string') ? new Buffer(data) : data;
+  }
 
   return self;
 }

--- a/src/https/form.js
+++ b/src/https/form.js
@@ -135,3 +135,22 @@ export function getData(formData) {
   data.contentLength = data.buffer.length;
   return data;
 }
+
+/*
+   Takes an key-value pair and turns them into a FormData object. This is for when
+   we want to upload a file using XMLHttpRequest.
+*/
+
+export function getFormData(formData) {
+  var data = new FormData();
+
+  for (var key in formData) {
+    if (key === 'file') {
+      data.append(key, formData[key].data, formData[key].name);
+    } else {
+      data.append(key, formData[key]);
+    }
+  }
+
+  return data;
+}


### PR DESCRIPTION
This pull request gives Snoocore the ability to upload files in the browser, which finishes up issue #9.

I've tested it with a bunch of different images in Chrome, and it seems to work pretty well.

File uploading uses the XMLHttpRequest [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData/Using_FormData_Objects) API, which can handle both [`File`](https://developer.mozilla.org/en/docs/Web/API/File) objects retrieved directly from an `<input />` element, and [`Blob`](https://developer.mozilla.org/en/docs/Web/API/Blob) if you want to use a file from elsewhere.