### PR TITLE
Only set "X-User-Agent" if in cookie mode

### DIFF
--- a/src/RedditRequest.js
+++ b/src/RedditRequest.js
@@ -57,7 +57,7 @@ export default class RedditRequest extends events.EventEmitter {
     if (this._userConfig.isNode) {
       // Can't set User-Agent in browser
       headers['User-Agent'] = this._userConfig.userAgent;
-    } else {
+    } else if (this._userConfig.useBrowserCookies) {
       // But the admins might appreciate this
       headers['X-User-Agent'] = this._userConfig.userAgent;
     }


### PR DESCRIPTION
A custom header like `X-User-Agent` can not be set in a cross-domain request because of CORS, so only set it if in browser cookie mode.