### PR TITLE
Also listen on request errors, eg, with code ETIMEDOUT or ECONNRESET

### DIFF
--- a/src/https/httpsNode.js
+++ b/src/https/httpsNode.js
@@ -64,6 +64,8 @@ export default function https(options, formData) {
       });
     });
 
+    req.on('error', error => { return reject(error); });
+
     if (options.method !== 'GET') {
       DEBUG_LOG('\n>>> request body:\n', data.buffer.toString());
       req.write(data.buffer);


### PR DESCRIPTION
After making about ~3000 requests to the Reddit API, I received a request error with a `ETIMEDOUT` code. This change listens for the error and rejects the corresponding promise.

Also, I request the `npm` version be rebuilt if this is merged in. Thanks!